### PR TITLE
Add support for CSIExternalVolumeInfoOptions

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -122,9 +122,9 @@ func (p *PersistentVolume) EmptyConstraints() *PersistentVolume {
 
 // ExternalVolume is an external volume definition
 type ExternalVolume struct {
-	Name     string             `json:"name,omitempty"`
-	Provider string             `json:"provider,omitempty"`
-	Options  *map[string]string `json:"options,omitempty"`
+	Name     string                  `json:"name,omitempty"`
+	Provider string                  `json:"provider,omitempty"`
+	Options  *map[string]interface{} `json:"options,omitempty"`
 }
 
 // PullConfig specifies a secret for authentication with a private Docker registry
@@ -231,7 +231,7 @@ func (ev *ExternalVolume) AddOption(name, value string) *ExternalVolume {
 
 // EmptyOptions explicitly empties the options
 func (ev *ExternalVolume) EmptyOptions() *ExternalVolume {
-	ev.Options = &map[string]string{}
+	ev.Options = &map[string]interface{}{}
 
 	return ev
 }

--- a/volumes_marshaling_test.go
+++ b/volumes_marshaling_test.go
@@ -1,0 +1,59 @@
+package marathon
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExternalVolumeParsing(t *testing.T) {
+	input := `{
+  "id": "app1",
+  "instances": 1,
+  "cpus": 1,
+  "mem": 1024,
+  "cmd": "echo yes > xxx/file && sleep 3600",
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "xxx",
+        "mode": "rw",
+        "external": {
+          "provider": "csi",
+          "name": "no-need",
+          "options": {
+            "pluginName": "nfs.csi.k8s.io",
+            "capability": {
+              "accessType": "mount",
+              "accessMode": "MULTI_NODE_MULTI_WRITER",
+              "fsType": "nfs"
+            },
+            "volumeContext": {
+              "server": "172.16.10.137",
+              "share": "/mnt"
+            }
+          }
+        }
+      }
+    ]
+  }
+}`
+
+	var app Application
+	err := json.Unmarshal([]byte(input), &app)
+	assert.NoError(t, err)
+	v := *app.Container.Volumes
+	assert.Equal(t, *v[0].External.Options, map[string]interface{}{
+		"pluginName": "nfs.csi.k8s.io",
+		"capability": map[string]interface{}{
+			"accessType": "mount",
+			"accessMode": "MULTI_NODE_MULTI_WRITER",
+			"fsType":     "nfs",
+		},
+		"volumeContext": map[string]interface{}{
+			"server": "172.16.10.137",
+			"share":  "/mnt",
+		},
+	})
+}


### PR DESCRIPTION
This change is not backward compatible since it changes the type of exported struct field.
The proper solution will be to create classes for `CSIExternalVolumeInfoOptions` and `DVDIExternalVolumeInfo` and deprecate
`ExternalVolume`.

Fixes: https://jira.d2iq.com/browse/DCOS_OSS-5991
Fixes: gambol99#368